### PR TITLE
Add check that IRMA consensus sequences exist to fix #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.0.1](https://github.com/peterk87/nf-iav-illumina/releases/tag/2.0.1)] - 2021-06-15
+
+Patch release to fix issue [#5](https://github.com/peterk87/nf-iav-illumina/issues/5); added check that IRMA `amended_consensus/` exists before concatenation of consensus FASTA files.
+
 ## [[2.0.0](https://github.com/peterk87/nf-iav-illumina/releases/tag/2.0.0)] - 2021-06-10
 
 ### :warning: Major enhancements

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -42,7 +42,9 @@ process IRMA {
 
   IRMA $params.irma_module $reads $meta.id
   
-  cat ${meta.id}/amended_consensus/*.fa > ${meta.id}.consensus.fasta
+  if [ -d "${meta.id}/amended_consensus/" ]; then
+    cat ${meta.id}/amended_consensus/*.fa > ${meta.id}.consensus.fasta
+  fi
 
   set +e
   IRMA | head -n1 | sed -E 's/^Iter.*IRMA\\), v(\\S+) .*/\\1/' > ${software}.version.txt

--- a/nextflow.config
+++ b/nextflow.config
@@ -94,7 +94,7 @@ manifest {
   description     = 'Influenza genome assembly with IRMA and consensus sequence analysis'
   homePage        = 'https://github.com/peterk87/nf-iav-illumina'
   author          = 'Peter Kruczkiewicz'
-  version         = '2.0.0'
+  version         = '2.0.1'
   nextflowVersion = '>=21.04'
   mainScript      = 'main.nf'
 }


### PR DESCRIPTION
Fix issue #5 by adding check that IRMA `amended_consensus/` directory exists before trying to concatenate consensus sequences into a single file.

Patch version bump (2.0.0 -> 2.0.1)

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] `CHANGELOG.md` is updated.
